### PR TITLE
Add type hints and mypy into CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+---
+name: Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  tests:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
+      - name: "Install dependencies"
+        run: "pip install -U pip && pip install . && pip install mypy"
+      - name: "Run mypy"
+        run: mypy src/Secweb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["*"]
 
 jobs:
   tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,19 +3,23 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
+dependencies = [
+    "starlette>=0.30,<1.0",
+]
 name = "Secweb-dev"
 version = "1.18.5"
 authors = [ { name="Motagamwala Taha Arif Ali", email = "tahaar5321@gmail.com" }, ]
 description = "Secweb is a pack of security middlewares for fastApi and starlette server it includes CSP, HSTS, and many more"
 readme = "README.md"
 keywords=['fastapi security header', 'security header', 'starlette security header', 'secweb', 'fastapi csp', 'starlette csp', 'csp']
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
+    "Typing :: Typed",
 ]
 
 [project.urls]
@@ -23,3 +27,6 @@ Homepage = "https://github.com/tmotagam/Secweb"
 Documentation = "https://github.com/tmotagam/Secweb#readme"
 Repository = "https://github.com/tmotagam/Secweb.git"
 Issues = "https://github.com/tmotagam/Secweb/issues"
+
+[tool.mypy]
+strict = true

--- a/src/Secweb/CacheControl/CacheControlMiddleware.py
+++ b/src/Secweb/CacheControl/CacheControlMiddleware.py
@@ -3,8 +3,30 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from typing import TypedDict
 
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
+
+CacheControlOption = TypedDict(
+    "CacheControlOption",
+    {
+        "max-age": int,  # The maximum age of the cache in seconds
+        "s-maxage": int,  # The maximum age of the shared cache in seconds
+        "no-cache": bool,  # Specifies whether the cache should be bypassed
+        "no-store": bool,  # Specifies whether the cache should not store any response
+        "no-transform": bool,  # Specifies whether the cache should not transform the response
+        "must-revalidate": bool,  # Specifies whether the cache must revalidate the response
+        "proxy-revalidate": bool,  # Specifies whether the cache must revalidate the response on the proxy server
+        "must-understand": bool,  # Specifies whether the cache must understand the response
+        "private": bool,  # Specifies whether the cache response is specific to a user
+        "public": bool,  # Specifies whether the cache response is public
+        "immutable": bool,  # Specifies whether the cache response is immutable
+        "stale-while-revalidate": int,  # The maximum age of stale content in seconds while revalidating
+    },
+    total=False,
+)
 
 class CacheControl:
     ''' CacheControl class sets Cache-Control header.
@@ -13,22 +35,9 @@ class CacheControl:
         app.add_middleware(CacheControl, Option={})
 
     Parameter:
-        Option (dict): Optional dictionary containing cache control options.
-            - 'max-age' (int): The maximum age of the cache in seconds.
-            - 's-maxage' (int): The maximum age of the shared cache in seconds.
-            - 'no-cache' (bool): Specifies whether the cache should be bypassed.
-            - 'no-store' (bool): Specifies whether the cache should not store any response.
-            - 'no-transform' (bool): Specifies whether the cache should not transform the response.
-            - 'must-revalidate' (bool): Specifies whether the cache must revalidate the response.
-            - 'proxy-revalidate' (bool): Specifies whether the cache must revalidate the response on the proxy server.
-            - 'must-understand' (bool): Specifies whether the cache must understand the response.
-            - 'private' (bool): Specifies whether the cache response is specific to a user.
-            - 'public' (bool): Specifies whether the cache response is public.
-            - 'immutable' (bool): Specifies whether the cache response is immutable.
-            - 'stale-while-revalidate' (int): The maximum age of stale content in seconds while revalidating.
-    
+        Option (CacheControlOptions): Optional dictionary containing cache control options.
     '''
-    def __init__(self, app, Option = {'max-age': 86400, 'private': True }):
+    def __init__(self, app: Starlette, Option: CacheControlOption = {'max-age': 86400, 'private': True}):
         """
         Initializes a new instance of the class.
 
@@ -95,7 +104,7 @@ class CacheControl:
         if list(Option.keys()).__len__() != 0 :
             raise SyntaxError('Cache-Control has 12 options 1> "max-age" 2> "s-maxage" 3> "no-cache" 4> "no-store" 5> "no-transform" 6> "must-revalidate" 7> "proxy-revalidate" 8> "must-understand" 9> "private" 10> "public" 11> "immutable" 12> "stale-while-revalidate" ')
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -110,7 +119,7 @@ class CacheControl:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Cache_Control(message):
+        async def set_Cache_Control(message: Message) -> None:
             """
             Set the Cache-Control header in the HTTP response.
 

--- a/src/Secweb/CacheControl/__init__.py
+++ b/src/Secweb/CacheControl/__init__.py
@@ -1,1 +1,6 @@
-from .CacheControlMiddleware import CacheControl
+from .CacheControlMiddleware import CacheControl, CacheControlOption
+
+__all__ = [
+    "CacheControl",
+    "CacheControlOption",
+]

--- a/src/Secweb/ClearSiteData/__init__.py
+++ b/src/Secweb/ClearSiteData/__init__.py
@@ -1,1 +1,7 @@
-from .ClearSiteDataMiddleware import ClearSiteData
+from .ClearSiteDataMiddleware import ClearSiteData, ClearSiteDataOption, ClearSiteDataAllowAllOption
+
+__all__ = [
+    "ClearSiteData",
+    "ClearSiteDataOption",
+    "ClearSiteDataAllowAllOption",
+]

--- a/src/Secweb/ContentSecurityPolicy/ContentSecurityPolicyMiddleware.py
+++ b/src/Secweb/ContentSecurityPolicy/ContentSecurityPolicyMiddleware.py
@@ -3,14 +3,19 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
 from secrets import token_urlsafe
+from typing import TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
 
-nonce = None
+nonce: str | None = None
 
-def Nonce_Processor(DEFAULT_ENTROPY=90):
+def Nonce_Processor(DEFAULT_ENTROPY: int = 90) -> str:
     """
     Generate a nonce using the `token_urlsafe` function.
 
@@ -25,6 +30,43 @@ def Nonce_Processor(DEFAULT_ENTROPY=90):
     nonce = token_urlsafe(DEFAULT_ENTROPY)
     return nonce
 
+
+ContentSecurityPolicyOption = TypedDict(
+    "ContentSecurityPolicyOption",
+    {
+        "child-src": list[str],
+        "connect-src": list[str],
+        "default-src": list[str],
+        'frame-src': list[str],
+        "base-uri": list[str],
+        "block-all-mixed-content": list[str],
+        "font-src": list[str],
+        "frame-ancestors": list[str],
+        "img-src": list[str],
+        'manifest-src': list[str],
+        'media-src': list[str],
+        "object-src": list[str],
+        "script-src": list[str],
+        'script-src-elem': list[str],
+        "script-src-attr": list[str],
+        "style-src": list[str],
+        'style-src-elem': list[str],
+        'style-src-attr': list[str],
+        'worker-src': list[str],
+        'plugin-types': list[str],
+        'sandbox': list[str],
+        'form-action': list[str],
+        'navigate-to': list[str],
+        'report-uri': list[str],
+        'report-to': list[str],
+        'trusted-types': list[str],
+        "upgrade-insecure-requests": list[str],
+        "require-trusted-types-for": list[str],
+    },
+    total=False,
+)
+
+
 class ContentSecurityPolicy:
     ''' ContentSecurityPolicy class sets Content-Security-Policy/Content-Security-Policy-Report-Only header.
 
@@ -38,7 +80,14 @@ class ContentSecurityPolicy:
         Option (dict, optional): The Option parameter. Defaults to {'default-src': ["'self'"], 'base-uri': ["'self'"], 'block-all-mixed-content': [], 'font-src': ["'self'", 'https:', 'data:'], 'frame-ancestors': ["'self'"], 'img-src': ["'self'", 'data:'], "object-src": ["'none'"], "script-src": ["'self'"], "script-src-attr": ["'none'"], "style-src": ["'self'", "https:", "'unsafe-inline'"], "upgrade-insecure-requests": [], "require-trusted-types-for": ["'script'"]}.
     
     '''
-    def __init__(self, app, script_nonce: bool = False, report_only: bool = False, style_nonce: bool = False, Option = {'default-src': ["'self'"], 'base-uri': ["'self'"], 'block-all-mixed-content': [], 'font-src': ["'self'", 'https:', 'data:'], 'frame-ancestors': ["'self'"], 'img-src': ["'self'", 'data:'], "object-src": ["'none'"], "script-src": ["'self'"], "script-src-attr": ["'none'"], "style-src": ["'self'", "https:", "'unsafe-inline'"], "upgrade-insecure-requests": [], "require-trusted-types-for": ["'script'"]}):
+    def __init__(
+            self,
+            app: Starlette,
+            script_nonce: bool = False,
+            report_only: bool = False,
+            style_nonce: bool = False,
+            Option: ContentSecurityPolicyOption = {'default-src': ["'self'"], 'base-uri': ["'self'"], 'block-all-mixed-content': [], 'font-src': ["'self'", 'https:', 'data:'], 'frame-ancestors': ["'self'"], 'img-src': ["'self'", 'data:'], "object-src": ["'none'"], "script-src": ["'self'"], "script-src-attr": ["'none'"], "style-src": ["'self'", "https:", "'unsafe-inline'"], "upgrade-insecure-requests": [], "require-trusted-types-for": ["'script'"]},
+    ):
         """
         Initialize the class with the given parameters.
 
@@ -46,7 +95,7 @@ class ContentSecurityPolicy:
             app (type): The app parameter.
             script_nonce (bool, optional): The script_nonce parameter. Defaults to False.
             style_nonce (bool, optional): The style_nonce parameter. Defaults to False.
-            Option (dict, optional): The Option parameter. Defaults to {'default-src': ["'self'"], 'base-uri': ["'self'"], 'block-all-mixed-content': [], 'font-src': ["'self'", 'https:', 'data:'], 'frame-ancestors': ["'self'"], 'img-src': ["'self'", 'data:'], "object-src": ["'none'"], "script-src": ["'self'"], "script-src-attr": ["'none'"], "style-src": ["'self'", "https:", "'unsafe-inline'"], "upgrade-insecure-requests": [], "require-trusted-types-for": ["'script'"]}.
+            Option (ContentSecurityPolicyOption, optional): The Option parameter. Defaults to {'default-src': ["'self'"], 'base-uri': ["'self'"], 'block-all-mixed-content': [], 'font-src': ["'self'", 'https:', 'data:'], 'frame-ancestors': ["'self'"], 'img-src': ["'self'", 'data:'], "object-src": ["'none'"], "script-src": ["'self'"], "script-src-attr": ["'none'"], "style-src": ["'self'", "https:", "'unsafe-inline'"], "upgrade-insecure-requests": [], "require-trusted-types-for": ["'script'"]}.
 
         Returns:
             None
@@ -60,7 +109,7 @@ class ContentSecurityPolicy:
         Policy = ['child-src', 'connect-src', 'default-src', 'font-src', 'frame-src', 'img-src', 'manifest-src', 'media-src', 'object-src', 'script-src', 'script-src-elem', 'script-src-attr', 'style-src', 'style-src-elem', 'style-src-attr', 'worker-src', 'base-uri', 'plugin-types', 'sandbox', 'form-action', 'frame-ancestors', 'navigate-to', 'report-uri', 'report-to', 'block-all-mixed-content', 'require-trusted-types-for', 'trusted-types', 'upgrade-insecure-requests']
         self.__PolicyCheck__(Option, Policy)
     
-    def __PolicyCheck__(self, Option, Policy):
+    def __PolicyCheck__(self, Option: ContentSecurityPolicyOption, Policy: list[str]) -> None:
         """
         Check the policy for a given option and update the policy string.
 
@@ -96,7 +145,7 @@ class ContentSecurityPolicy:
                 raise SyntaxError(f'The Policy {key} does not exist')
 
             self.PolicyString += key
-            values = Option[key]
+            values = Option[key]  # type: ignore[literal-required]
 
             if (key == 'script-src' and self.script_nonce and len(values) == 0) or (key == 'style-src' and self.style_nonce and len(values) == 0):
                 self.PolicyString += " "
@@ -120,7 +169,7 @@ class ContentSecurityPolicy:
                 else:
                     self.PolicyString += ' '
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -137,7 +186,7 @@ class ContentSecurityPolicy:
 
         PS = self.PolicyString
 
-        async def set_Content_Security_Policy(message):
+        async def set_Content_Security_Policy(message: Message) -> None:
             """
             Sets the Content-Security-Policy header in the HTTP response.
 

--- a/src/Secweb/ContentSecurityPolicy/__init__.py
+++ b/src/Secweb/ContentSecurityPolicy/__init__.py
@@ -1,2 +1,8 @@
-from .ContentSecurityPolicyMiddleware import ContentSecurityPolicy
-from .ContentSecurityPolicyMiddleware import Nonce_Processor
+from .ContentSecurityPolicyMiddleware import ContentSecurityPolicy, Nonce_Processor, ContentSecurityPolicyOption
+
+__all__ = [
+    "ContentSecurityPolicy",
+    "Nonce_Processor",
+    "ContentSecurityPolicyOption",
+    "ContentSecurityPolicyMiddleware",
+]

--- a/src/Secweb/CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicyMiddleware.py
+++ b/src/Secweb/CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicyMiddleware.py
@@ -3,9 +3,26 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
+from typing import TypedDict, Literal
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+from typing_extensions import TypeAlias
+
+TCrossOriginEmbedderPolicyOption: TypeAlias = Literal['require-corp', 'unsafe-none', 'credentialless']
+
+CrossOriginEmbedderPolicyOption = TypedDict(
+    "CrossOriginEmbedderPolicyOption",
+    {
+        "Cross-Origin-Embedder-Policy": TCrossOriginEmbedderPolicyOption,
+    },
+    total=False,
+)
+
 
 class CrossOriginEmbedderPolicy:
     ''' CrossOriginEmbedderPolicy class sets Cross-Origin-Embedder-Policy header.
@@ -17,7 +34,11 @@ class CrossOriginEmbedderPolicy:
         Option: The option for the class. Defaults to 'unsafe-none'.
     
     '''
-    def __init__(self, app, Option = 'unsafe-none'):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: TCrossOriginEmbedderPolicyOption | CrossOriginEmbedderPolicyOption = 'unsafe-none',
+    ):
         """
         Initializes the class with the given `app` and `Option` parameters.
 
@@ -39,7 +60,7 @@ class CrossOriginEmbedderPolicy:
             if self.Option not in Policies:
                 raise SyntaxError('CrossOriginEmbedderPolicy has 3 options 1> "unsafe-none" 2> "require-corp" 3> "credentialless"')
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -54,7 +75,7 @@ class CrossOriginEmbedderPolicy:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Cross_Origin_Embedder_Policy(message):
+        async def set_Cross_Origin_Embedder_Policy(message: Message) -> None:
             """
             Set the Cross-Origin-Embedder-Policy header in the response headers.
             

--- a/src/Secweb/CrossOriginEmbedderPolicy/__init__.py
+++ b/src/Secweb/CrossOriginEmbedderPolicy/__init__.py
@@ -1,1 +1,7 @@
-from .CrossOriginEmbedderPolicyMiddleware import CrossOriginEmbedderPolicy
+from .CrossOriginEmbedderPolicyMiddleware import CrossOriginEmbedderPolicy, TCrossOriginEmbedderPolicyOption, CrossOriginEmbedderPolicyOption
+
+__all__ = [
+    "CrossOriginEmbedderPolicy",
+    "CrossOriginEmbedderPolicyOption",
+    "TCrossOriginEmbedderPolicyOption",
+]

--- a/src/Secweb/CrossOriginOpenerPolicy/CrossOriginOpenerPolicyMiddleware.py
+++ b/src/Secweb/CrossOriginOpenerPolicy/CrossOriginOpenerPolicyMiddleware.py
@@ -3,9 +3,25 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
+from typing import Literal, TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+from typing_extensions import TypeAlias
+
+TCrossOriginOpenerPolicyOption: TypeAlias = Literal["unsafe-none", "same-origin-allow-popups", "same-origin"]
+
+CrossOriginOpenerPolicyOption = TypedDict(
+    "CrossOriginOpenerPolicyOption",
+    {
+        "Cross-Origin-Opener-Policy": TCrossOriginOpenerPolicyOption,
+    },
+    total=False,
+)
 
 class CrossOriginOpenerPolicy:
     ''' CrossOriginOpenerPolicy class sets Cross-Origin-Opener-Policy header.
@@ -17,7 +33,11 @@ class CrossOriginOpenerPolicy:
         Option (str): The option for the class. Defaults to 'unsafe-none'.
     
     '''
-    def __init__(self, app, Option = 'unsafe-none'):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: TCrossOriginOpenerPolicyOption | CrossOriginOpenerPolicyOption = 'unsafe-none',
+    ):
         """
         Initializes an instance of the class.
 
@@ -42,7 +62,7 @@ class CrossOriginOpenerPolicy:
             if self.Option not in Policies:
                 raise SyntaxError('CrossOriginOpenerPolicy has 3 options 1> "unsafe-none" 2> "same-origin-allow-popups" 3> "same-origin"')
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -57,7 +77,7 @@ class CrossOriginOpenerPolicy:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Cross_Origin_Opener_Policy(message):
+        async def set_Cross_Origin_Opener_Policy(message: Message) -> None:
             """
             Sets the Cross-Origin-Opener-Policy header in the HTTP response headers.
             

--- a/src/Secweb/CrossOriginOpenerPolicy/__init__.py
+++ b/src/Secweb/CrossOriginOpenerPolicy/__init__.py
@@ -1,1 +1,7 @@
-from .CrossOriginOpenerPolicyMiddleware import CrossOriginOpenerPolicy
+from .CrossOriginOpenerPolicyMiddleware import CrossOriginOpenerPolicy, TCrossOriginOpenerPolicyOption, CrossOriginOpenerPolicyOption
+
+__all__ = [
+    "CrossOriginOpenerPolicy",
+    "TCrossOriginOpenerPolicyOption",
+    "CrossOriginOpenerPolicyOption",
+]

--- a/src/Secweb/CrossOriginResourcePolicy/CrossOriginResourcePolicyMiddleware.py
+++ b/src/Secweb/CrossOriginResourcePolicy/CrossOriginResourcePolicyMiddleware.py
@@ -3,9 +3,26 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
+from typing import Literal, TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
+from typing_extensions import TypeAlias
+
+TCrossOriginResourcePolicyOption: TypeAlias = Literal["same-site", "same-origin", "cross-origin"]
+
+CrossOriginResourcePolicyOption = TypedDict(
+    "CrossOriginResourcePolicyOption",
+    {
+        "Cross-Origin-Resource-Policy": TCrossOriginResourcePolicyOption,
+    },
+    total=False,
+)
+
 
 class CrossOriginResourcePolicy:
     ''' CrossOriginResourcePolicy class sets Cross-Origin-Resource-Policy header.
@@ -17,7 +34,11 @@ class CrossOriginResourcePolicy:
         Option (str): The option for the class. Default is 'cross-origin'.
         
     '''
-    def __init__(self, app, Option = 'cross-origin'):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: TCrossOriginResourcePolicyOption | CrossOriginResourcePolicyOption = 'cross-origin',
+    ):
         """
         Initializes an instance of the class.
 
@@ -42,7 +63,7 @@ class CrossOriginResourcePolicy:
             if self.Option not in Policies:
                 raise SyntaxError('CrossOriginResourcePolicy has 3 options 1> "same-site" 2> "same-origin" 3> "cross-origin"')
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -57,7 +78,7 @@ class CrossOriginResourcePolicy:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Cross_Origin_Resource_Policy(message):
+        async def set_Cross_Origin_Resource_Policy(message: Message) -> None:
             """
             Sets the Cross-Origin Resource Policy header in the response headers.
 

--- a/src/Secweb/CrossOriginResourcePolicy/__init__.py
+++ b/src/Secweb/CrossOriginResourcePolicy/__init__.py
@@ -1,1 +1,7 @@
-from .CrossOriginResourcePolicyMiddleware import CrossOriginResourcePolicy
+from .CrossOriginResourcePolicyMiddleware import CrossOriginResourcePolicy, TCrossOriginResourcePolicyOption, CrossOriginResourcePolicyOption
+
+__all__ = [
+    "CrossOriginResourcePolicy",
+    "TCrossOriginResourcePolicyOption",
+    "CrossOriginResourcePolicyOption",
+]

--- a/src/Secweb/OriginAgentCluster/OriginAgentClusterMiddleware.py
+++ b/src/Secweb/OriginAgentCluster/OriginAgentClusterMiddleware.py
@@ -3,8 +3,10 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
-
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+
 
 class OriginAgentCluster:
     ''' OriginAgentCluster sets the Origin-Agent-Cluster header.
@@ -13,7 +15,7 @@ class OriginAgentCluster:
         app.add_middleware(OriginAgentCluster)
     
     '''
-    def __init__(self, app):
+    def __init__(self, app: Starlette):
         """
         Initializes a new instance of the class.
 
@@ -25,7 +27,7 @@ class OriginAgentCluster:
         """
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -40,7 +42,7 @@ class OriginAgentCluster:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Origin_Agent_Cluster(message):
+        async def set_Origin_Agent_Cluster(message: Message) -> None:
             """
             Sets the Origin-Agent-Cluster header in the HTTP response.
 

--- a/src/Secweb/OriginAgentCluster/__init__.py
+++ b/src/Secweb/OriginAgentCluster/__init__.py
@@ -1,1 +1,5 @@
 from .OriginAgentClusterMiddleware import OriginAgentCluster
+
+__all__ = [
+    "OriginAgentCluster",
+]

--- a/src/Secweb/PermissionsPolicy/PermissionsPolicyMiddleware.py
+++ b/src/Secweb/PermissionsPolicy/PermissionsPolicyMiddleware.py
@@ -3,9 +3,54 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
-
+from typing import TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Message, Scope, Receive, Send
+
+PermissionsPolicyOption = TypedDict(
+    "PermissionsPolicyOption",
+    {
+        "accelerometer": list[str],
+        "ambient-light-sensor": list[str],
+        "attribution-reporting": list[str],
+        "autoplay": list[str],
+        "bluetooth": list[str],
+        "browsing-topics": list[str],
+        "camera": list[str],
+        "compute-pressure": list[str],
+        "display-capture": list[str],
+        "document-domain": list[str],
+        "encrypted-media": list[str],
+        "fullscreen": list[str],
+        "geolocation": list[str],
+        "gyroscope": list[str],
+        "hid": list[str],
+        "identity-credentials-get": list[str],
+        "idle-detection": list[str],
+        "local-fonts": list[str],
+        "magnetometer": list[str],
+        "microphone": list[str],
+        "midi": list[str],
+        "otp-credentials": list[str],
+        "payment": list[str],
+        "picture-in-picture": list[str],
+        "publickey-credentials-create": list[str],
+        "publickey-credentials-get": list[str],
+        "screen-wake-lock": list[str],
+        "serial": list[str],
+        "storage-access": list[str],
+        "usb": list[str],
+        "web-share": list[str],
+        'window-management':list[str]
+    },
+    total=False,
+
+)
+
+
 
 class PermissionsPolicy:
     '''PermissionsPolicy class sets Permissions-Policy header.
@@ -17,7 +62,7 @@ class PermissionsPolicy:
        Option (dict): The options for the permission policy.
     
     '''
-    def __init__(self, app, Option = {}):
+    def __init__(self, app: Starlette, Option: PermissionsPolicyOption = {}):
         """
         Initializes a new instance of the class.
 
@@ -43,7 +88,7 @@ class PermissionsPolicy:
             warn("Permission-Policy header is still under working draft, browsers might give warnings and errors", SyntaxWarning, 2)
             self.__PolicyCheck__(Option, Policy)
     
-    def __PolicyCheck__(self, Option, Policy):
+    def __PolicyCheck__(self, Option: PermissionsPolicyOption, Policy: list[str]) -> None:
         """
         Generate a policy string based on the given Option and Policy dictionaries.
 
@@ -93,7 +138,7 @@ class PermissionsPolicy:
                 else:
                     self.PolicyString += ' '
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -108,7 +153,7 @@ class PermissionsPolicy:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Permissions_Policy(message):
+        async def set_Permissions_Policy(message: Message) -> None:
             """
             Set the Permissions-Policy header in the HTTP response headers.
 

--- a/src/Secweb/PermissionsPolicy/__init__.py
+++ b/src/Secweb/PermissionsPolicy/__init__.py
@@ -1,1 +1,6 @@
-from .PermissionsPolicyMiddleware import PermissionsPolicy
+from .PermissionsPolicyMiddleware import PermissionsPolicy, PermissionsPolicyOption
+
+__all__ = [
+    "PermissionsPolicy",
+    "PermissionsPolicyOption",
+]

--- a/src/Secweb/ReferrerPolicy/ReferrerPolicyMiddleware.py
+++ b/src/Secweb/ReferrerPolicy/ReferrerPolicyMiddleware.py
@@ -3,9 +3,26 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
+from typing import Literal, TypedDict, Union
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+from typing_extensions import TypeAlias
+
+TReferrerPolicyOption: TypeAlias = Literal['no-referrer', 'no-referrer-when-downgrade', 'origin', 'origin-when-cross-origin', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url']
+
+ReferrerPolicyOption = TypedDict(
+    "ReferrerPolicyOption",
+    {
+        "Referrer-Policy": Union[list[TReferrerPolicyOption], TReferrerPolicyOption],
+    },
+    total=False,
+)
+
 
 class ReferrerPolicy:
     ''' ReferrerPolicy class sets Referrer-Policy header.
@@ -17,7 +34,11 @@ class ReferrerPolicy:
         Option (list[str], optional): The `Option` parameter is a list of string that contains the option for the `Referrer-Policy`. The default value is ['strict-origin-when-cross-origin'].
     
     '''
-    def __init__(self, app, Option = ['strict-origin-when-cross-origin']):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: Union[list[TReferrerPolicyOption], ReferrerPolicyOption] = ['strict-origin-when-cross-origin'],
+    ):
         """
         Initializes the class with the given `app` and `Option` parameters.
 
@@ -36,9 +57,9 @@ class ReferrerPolicy:
         self.policystring = ''
         if not isinstance(Option, list):
             warn('ReferrerPolicy middleware will now accept list of string(s) rather than dictonary eg. Option={"Referrer-Policy": "strict-origin-when-cross-origin"} will be Option=["strict-origin-when-cross-origin"]', SyntaxWarning, 2)
-            if Option['Referrer-Policy'] in Policies:
+            if isinstance(Option['Referrer-Policy'], str) and Option['Referrer-Policy'] in Policies:
                 self.policystring = Option['Referrer-Policy']
-            elif len(Option['Referrer-Policy']) > 1:
+            elif isinstance(Option['Referrer-Policy'], list) and len(Option['Referrer-Policy']) > 1:
                 for option in Option['Referrer-Policy']:
                     if option not in Policies:
                         raise SyntaxError('Referrer-Policy has 8 options 1> "no-referrer" 2> "no-referrer-when-downgrade" 3> "origin" 4> "origin-when-cross-origin" 5> "same-origin" 6> "strict-origin" 7> "strict-origin-when-cross-origin" 8> "unsafe-url"')
@@ -51,7 +72,7 @@ class ReferrerPolicy:
                     raise SyntaxError('ReferrerPolicy has 8 options 1> "no-referrer" 2> "no-referrer-when-downgrade" 3> "origin" 4> "origin-when-cross-origin" 5> "same-origin" 6> "strict-origin" 7> "strict-origin-when-cross-origin" 8> "unsafe-url"')
             self.policystring = ', '.join(Option)
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -66,7 +87,7 @@ class ReferrerPolicy:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Referrer_Policy(message):
+        async def set_Referrer_Policy(message: Message) -> None:
             """
             Set the Referrer-Policy header in the HTTP response.
 

--- a/src/Secweb/ReferrerPolicy/__init__.py
+++ b/src/Secweb/ReferrerPolicy/__init__.py
@@ -1,1 +1,7 @@
-from .ReferrerPolicyMiddleware import ReferrerPolicy
+from .ReferrerPolicyMiddleware import ReferrerPolicy, TReferrerPolicyOption, ReferrerPolicyOption
+
+__all__ = [
+    "ReferrerPolicy",
+    "TReferrerPolicyOption",
+    "ReferrerPolicyOption",
+]

--- a/src/Secweb/StrictTransportSecurity/StrictTransportSecurityMiddleware.py
+++ b/src/Secweb/StrictTransportSecurity/StrictTransportSecurityMiddleware.py
@@ -3,8 +3,22 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from typing import TypedDict
 
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
+
+HSTSOption = TypedDict(
+    "HSTSOption",
+    {
+        "max-age": int,
+        "includeSubDomains": bool,
+        "preload": bool,
+    },
+    total=False,
+)
+
 
 class HSTS:
     ''' HSTS class sets Strict-Transport-Security Header.
@@ -16,13 +30,17 @@ class HSTS:
         Option (dict, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
 
     '''
-    def __init__(self, app, Option = {'max-age': 432000, 'includeSubDomains': True, 'preload': False}):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: HSTSOption = {'max-age': 432000, 'includeSubDomains': True, 'preload': False},
+    ):
         """
         Initializes an instance of the class.
 
         Args:
             app (object): The application object.
-            Option (dict, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
+            Option (HSTSOption, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
 
         Raises:
             SyntaxError: If 'max-age' is not a positive integer or if the 'Option' dictionary is not valid.
@@ -50,7 +68,7 @@ class HSTS:
         else:
             raise SyntaxError('Strict-Transport-Security has 3 options 1> "max-age=<expire-time>" <- This is the compulsory option 2> "includeSubDomains" 3> "preload"')
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -65,7 +83,7 @@ class HSTS:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_Strict_Transport_Security(message):
+        async def set_Strict_Transport_Security(message: Message) -> None:
             """
             Sets the Strict-Transport-Security header in the HTTP response start event.
 

--- a/src/Secweb/StrictTransportSecurity/__init__.py
+++ b/src/Secweb/StrictTransportSecurity/__init__.py
@@ -1,1 +1,6 @@
-from .StrictTransportSecurityMiddleware import HSTS
+from .StrictTransportSecurityMiddleware import HSTS, HSTSOption
+
+__all__ = [
+    "HSTS",
+    "HSTSOption",
+]

--- a/src/Secweb/WsStrictTransportSecurity/WsStrictTransportSecurityMiddleware.py
+++ b/src/Secweb/WsStrictTransportSecurity/WsStrictTransportSecurityMiddleware.py
@@ -3,8 +3,22 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from typing import TypedDict
 
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
+
+WsHSTSOption = TypedDict(
+    "WsHSTSOption",
+    {
+        "max-age": int,
+        "includeSubDomains": bool,
+        "preload": bool,
+    },
+    total=False,
+)
+
 
 class WsHSTS:
     ''' HSTS class sets Strict-Transport-Security Header for Websocket.
@@ -13,16 +27,20 @@ class WsHSTS:
         app.add_middleware(WsHSTS, Option={})
 
     Parameter :
-        Option (dict, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
+        Option (WsHSTSOption, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
     
     '''
-    def __init__(self, app, Option = {'max-age': 432000, 'includeSubDomains': True, 'preload': False}):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: WsHSTSOption = {'max-age': 432000, 'includeSubDomains': True, 'preload': False},
+    ):
         """
         Initializes an instance of the class.
 
         Args:
             app (object): The application object.
-            Option (dict, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
+            Option (WsHSTSOption, optional): The options for the class. Defaults to {'max-age': 432000, 'includeSubDomains': True, 'preload': False}.
 
         Raises:
             SyntaxError: If 'max-age' is not a positive integer or if the 'Option' dictionary is not valid.
@@ -50,7 +68,7 @@ class WsHSTS:
         else:
             raise SyntaxError('Strict-Transport-Security has 3 options 1> "max-age=<expire-time>" <- This is the compulsory option 2> "includeSubDomains" 3> "preload"')
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles Websocket requests by routing them to the appropriate handler based on the request path.
 
@@ -62,7 +80,7 @@ class WsHSTS:
         if scope["type"] != "websocket":
             return await self.app(scope, receive, send)
 
-        async def set_Strict_Transport_Security(message):  
+        async def set_Strict_Transport_Security(message: Message) -> None:
             """
             Set the Strict-Transport-Security header in the response headers if the message type is "websocket.accept".
             

--- a/src/Secweb/WsStrictTransportSecurity/__init__.py
+++ b/src/Secweb/WsStrictTransportSecurity/__init__.py
@@ -1,1 +1,6 @@
-from .WsStrictTransportSecurityMiddleware import WsHSTS
+from .WsStrictTransportSecurityMiddleware import WsHSTS, WsHSTSOption
+
+__all__ = [
+    "WsHSTS",
+    "WsHSTSOption",
+]

--- a/src/Secweb/XContentTypeOptions/XContentTypeOptionsMiddleware.py
+++ b/src/Secweb/XContentTypeOptions/XContentTypeOptionsMiddleware.py
@@ -3,8 +3,9 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
-
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
 
 class XContentTypeOptions:
     ''' XContentTypeOptions sets the X-Content-Type-Options header.
@@ -13,7 +14,7 @@ class XContentTypeOptions:
         app.add_middleware(XContentTypeOptions)
     
     '''
-    def __init__(self, app):
+    def __init__(self, app: Starlette):
         """
         Initializes a new instance of the class.
 
@@ -25,7 +26,7 @@ class XContentTypeOptions:
         """
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -40,7 +41,7 @@ class XContentTypeOptions:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_x_Content_Type_Options(message):
+        async def set_x_Content_Type_Options(message: Message) -> None:
             """
             Sets the 'X-Content-Type-Options' header in the response headers'.
 

--- a/src/Secweb/XContentTypeOptions/__init__.py
+++ b/src/Secweb/XContentTypeOptions/__init__.py
@@ -1,1 +1,5 @@
 from .XContentTypeOptionsMiddleware import XContentTypeOptions
+
+__all__ = [
+    "XContentTypeOptions",
+]

--- a/src/Secweb/XDNSPrefetchControl/XDNSPrefetchControlMiddleware.py
+++ b/src/Secweb/XDNSPrefetchControl/XDNSPrefetchControlMiddleware.py
@@ -3,9 +3,24 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
-
+from __future__ import annotations
+from typing import Literal, TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+from typing_extensions import TypeAlias
+
+TXDNSPrefetchControlOption: TypeAlias = Literal['on', 'off']
+
+XDNSPrefetchControlOption = TypedDict(
+    "XDNSPrefetchControlOption",
+    {
+        "X-DNS-Prefetch-Control": TXDNSPrefetchControlOption,
+    },
+)
+
 
 class XDNSPrefetchControl:
     ''' XDNSPrefetchControl class sets X-DNS-Prefetch-Control header.
@@ -17,7 +32,11 @@ class XDNSPrefetchControl:
         Option (str): Optional. The option for the class object. Defaults to 'off'.
     
     '''
-    def __init__(self, app, Option = 'off'):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: XDNSPrefetchControlOption | TXDNSPrefetchControlOption = 'off',
+    ):
         """
         Initializes the class object.
 
@@ -38,7 +57,7 @@ class XDNSPrefetchControl:
             if self.Option != 'on' and self.Option != 'off':
                 raise SyntaxError('XDNSPrefetchControl has two values only 1> "on" 2> "off"') 
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self,scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -53,7 +72,7 @@ class XDNSPrefetchControl:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_x_DNS_Prefetch_Control(message):
+        async def set_x_DNS_Prefetch_Control(message: Message) -> None:
             """
             Sets the value of the `X-DNS-Prefetch-Control` header in the response headers.
 

--- a/src/Secweb/XDNSPrefetchControl/__init__.py
+++ b/src/Secweb/XDNSPrefetchControl/__init__.py
@@ -1,1 +1,7 @@
-from .XDNSPrefetchControlMiddleware import XDNSPrefetchControl
+from .XDNSPrefetchControlMiddleware import XDNSPrefetchControl, TXDNSPrefetchControlOption, XDNSPrefetchControlOption
+
+__all__ = [
+    "XDNSPrefetchControl",
+    "TXDNSPrefetchControlOption",
+    "XDNSPrefetchControlOption",
+]

--- a/src/Secweb/XDownloadOptions/XDownloadOptionsMiddleware.py
+++ b/src/Secweb/XDownloadOptions/XDownloadOptionsMiddleware.py
@@ -3,8 +3,10 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
-
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
+
 
 class XDownloadOptions:
     ''' XDownloadOptions sets the X-Download-Options header.
@@ -13,7 +15,7 @@ class XDownloadOptions:
         app.add_middleware(XDownloadOptions)
     
     '''
-    def __init__(self, app):
+    def __init__(self, app: Starlette):
         """
         Initializes a new instance of the class.
 
@@ -21,7 +23,7 @@ class XDownloadOptions:
         """
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -36,7 +38,7 @@ class XDownloadOptions:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_x_Download_Options(message):
+        async def set_x_Download_Options(message: Message) -> None:
             """
             Set the X-Download-Options header in the HTTP response header.
 

--- a/src/Secweb/XDownloadOptions/__init__.py
+++ b/src/Secweb/XDownloadOptions/__init__.py
@@ -1,1 +1,5 @@
 from .XDownloadOptionsMiddleware import XDownloadOptions
+
+__all__ = [
+    "XDownloadOptions",
+]

--- a/src/Secweb/XFrameOptions/XFrameOptionsMiddleware.py
+++ b/src/Secweb/XFrameOptions/XFrameOptionsMiddleware.py
@@ -3,9 +3,25 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
+from typing import Literal, TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+from typing_extensions import TypeAlias
+
+TXFrameOption: TypeAlias = Literal['SAMEORIGIN', 'DENY']
+
+XFrameOption = TypedDict(
+    "XFrameOption",
+    {
+        "X-Frame-Options": TXFrameOption,
+    },
+)
+
 
 class XFrame:
     ''' XFrame class sets X-Frame-Options header.
@@ -17,7 +33,7 @@ class XFrame:
         Option (str, optional): Option for the function. Defaults to 'DENY'.
 
     '''
-    def __init__(self, app, Option = 'DENY'):
+    def __init__(self, app: Starlette, Option: XFrameOption | TXFrameOption = 'DENY'):
         """
         Initializes a new instance of the class.
 
@@ -41,7 +57,7 @@ class XFrame:
             if self.Option != 'SAMEORIGIN' and self.Option != 'DENY':
                 raise SyntaxError('XFrame has two values only 1> "DENY" 2> "SAMEORIGIN"') 
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -56,7 +72,7 @@ class XFrame:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_x_Frame_Options(message):
+        async def set_x_Frame_Options(message: Message) -> None:
             """
             Sets the 'X-Frame-Options' header in the response header.
 

--- a/src/Secweb/XFrameOptions/__init__.py
+++ b/src/Secweb/XFrameOptions/__init__.py
@@ -1,1 +1,7 @@
-from .XFrameOptionsMiddleware import XFrame
+from .XFrameOptionsMiddleware import XFrame, TXFrameOption, XFrameOption
+
+__all__ = [
+    "XFrame",
+    "TXFrameOption",
+    "XFrameOption",
+]

--- a/src/Secweb/XPermittedCrossDomainPolicies/XPermittedCrossDomainPoliciesMiddleware.py
+++ b/src/Secweb/XPermittedCrossDomainPolicies/XPermittedCrossDomainPoliciesMiddleware.py
@@ -3,9 +3,25 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from __future__ import annotations
 
+from typing import Literal, TypedDict
 from warnings import warn
+
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Send, Receive, Scope, Message
+from typing_extensions import TypeAlias
+
+TXPermittedCrossDomainPoliciesOption: TypeAlias = Literal['none', 'master-only', 'by-content-type', 'all']
+
+XPermittedCrossDomainPoliciesOption = TypedDict(
+    "XPermittedCrossDomainPoliciesOption",
+    {
+        "X-Permitted-Cross-Domain-Policies": TXPermittedCrossDomainPoliciesOption,
+    },
+)
+
 
 class XPermittedCrossDomainPolicies:
     ''' XPermittedCrossDomainPolicies class sets X-Permitted-Cross-Domain-Policies header.
@@ -17,7 +33,11 @@ class XPermittedCrossDomainPolicies:
         Option (str): Optional cross-domain policy option. Default is 'none'.
 
     '''
-    def __init__(self, app, Option = 'none'):
+    def __init__(
+            self,
+            app: Starlette,
+            Option: XPermittedCrossDomainPoliciesOption | TXPermittedCrossDomainPoliciesOption = 'none',
+    ):
         """
         Initializes the class with the given app and optional cross-domain policy option.
 
@@ -42,7 +62,7 @@ class XPermittedCrossDomainPolicies:
             if self.Option not in Policies:
                 raise SyntaxError('XPermittedCrossDomainPolicies has four values 1> "none" 2> "master-only" 3> "by-content-type" 4> "all"') 
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -57,7 +77,7 @@ class XPermittedCrossDomainPolicies:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_x_Permitted_Cross_Domain_Policies(message):
+        async def set_x_Permitted_Cross_Domain_Policies(message: Message) -> None:
             """
             Set the X-Permitted-Cross-Domain-Policies header in the response headers.
 

--- a/src/Secweb/XPermittedCrossDomainPolicies/__init__.py
+++ b/src/Secweb/XPermittedCrossDomainPolicies/__init__.py
@@ -1,1 +1,7 @@
-from .XPermittedCrossDomainPoliciesMiddleware import XPermittedCrossDomainPolicies
+from .XPermittedCrossDomainPoliciesMiddleware import XPermittedCrossDomainPolicies, TXPermittedCrossDomainPoliciesOption, XPermittedCrossDomainPoliciesOption
+
+__all__ = [
+    "XPermittedCrossDomainPolicies",
+    "TXPermittedCrossDomainPoliciesOption",
+    "XPermittedCrossDomainPoliciesOption",
+]

--- a/src/Secweb/index.py
+++ b/src/Secweb/index.py
@@ -3,24 +3,47 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
+from typing import TypedDict, Literal, Union
 
-from .WsStrictTransportSecurity.WsStrictTransportSecurityMiddleware import WsHSTS
-from .XFrameOptions.XFrameOptionsMiddleware import XFrame
-from .CrossOriginEmbedderPolicy.CrossOriginEmbedderPolicyMiddleware import CrossOriginEmbedderPolicy
-from .CrossOriginOpenerPolicy.CrossOriginOpenerPolicyMiddleware import CrossOriginOpenerPolicy
-from .CrossOriginResourcePolicy.CrossOriginResourcePolicyMiddleware import CrossOriginResourcePolicy
-from .xXSSProtection.xXSSProtectionMiddleware import xXSSProtection
-from .StrictTransportSecurity.StrictTransportSecurityMiddleware import HSTS
-from .XPermittedCrossDomainPolicies.XPermittedCrossDomainPoliciesMiddleware import XPermittedCrossDomainPolicies
-from .XDownloadOptions.XDownloadOptionsMiddleware import XDownloadOptions
-from .XDNSPrefetchControl.XDNSPrefetchControlMiddleware import XDNSPrefetchControl
-from .XContentTypeOptions.XContentTypeOptionsMiddleware import XContentTypeOptions
-from .ReferrerPolicy.ReferrerPolicyMiddleware import ReferrerPolicy
-from .OriginAgentCluster.OriginAgentClusterMiddleware import OriginAgentCluster
-from .ContentSecurityPolicy.ContentSecurityPolicyMiddleware import ContentSecurityPolicy
-from .PermissionsPolicy.PermissionsPolicyMiddleware import PermissionsPolicy
-from .ClearSiteData.ClearSiteDataMiddleware import ClearSiteData
-from .CacheControl.CacheControlMiddleware import CacheControl
+from starlette.applications import Starlette
+
+from .WsStrictTransportSecurity import WsHSTS, WsHSTSOption
+from .XFrameOptions import XFrame, TXFrameOption, XFrameOption
+from .CrossOriginEmbedderPolicy import CrossOriginEmbedderPolicy, CrossOriginEmbedderPolicyOption, TCrossOriginEmbedderPolicyOption
+from .CrossOriginOpenerPolicy import CrossOriginOpenerPolicy, TCrossOriginOpenerPolicyOption, CrossOriginOpenerPolicyOption
+from .CrossOriginResourcePolicy import CrossOriginResourcePolicy, TCrossOriginResourcePolicyOption, CrossOriginResourcePolicyOption
+from .xXSSProtection import xXSSProtection
+from .StrictTransportSecurity import HSTS, HSTSOption
+from .XPermittedCrossDomainPolicies import XPermittedCrossDomainPolicies, TXPermittedCrossDomainPoliciesOption, XPermittedCrossDomainPoliciesOption
+from .XDownloadOptions import XDownloadOptions
+from .XDNSPrefetchControl import XDNSPrefetchControl, TXDNSPrefetchControlOption, XDNSPrefetchControlOption
+from .XContentTypeOptions import XContentTypeOptions
+from .ReferrerPolicy import ReferrerPolicy, TReferrerPolicyOption, ReferrerPolicyOption
+from .OriginAgentCluster import OriginAgentCluster
+from .ContentSecurityPolicy import ContentSecurityPolicy, ContentSecurityPolicyOption
+from .PermissionsPolicy import PermissionsPolicy, PermissionsPolicyOption
+from .ClearSiteData import ClearSiteData, ClearSiteDataOption
+from .CacheControl import CacheControl, CacheControlOption
+
+
+class SecWebOption(TypedDict, total=False):
+    xdo: bool  # X-Download-Options
+    xcto: bool  # X-Content-Type-Options
+    oac: bool  # Origin-Agent-Cluster
+    xss: bool  # X-XSS-Protection
+    csp: Union[Literal[False], ContentSecurityPolicyOption]  # Content-Security-Policy
+    coop: Union[Literal[False], TCrossOriginOpenerPolicyOption, CrossOriginOpenerPolicyOption]  # Cross-Origin-Opener-Policy
+    coep: Union[Literal[False], TCrossOriginEmbedderPolicyOption, CrossOriginEmbedderPolicyOption]  # Cross-Origin-Embedder-Policy
+    corp: Union[Literal[False], TCrossOriginResourcePolicyOption, CrossOriginResourcePolicyOption]  # Cross-Origin-Resource-Policy
+    referrer: Union[Literal[False], TReferrerPolicyOption, ReferrerPolicyOption]  # Referrer-Policy
+    xdns: Union[Literal[False], TXDNSPrefetchControlOption, XDNSPrefetchControlOption]  # X-DNS-Prefetch-Control
+    xcdp: Union[Literal[False], TXPermittedCrossDomainPoliciesOption, XPermittedCrossDomainPoliciesOption]  # X-Permitted-Cross-Domain-Policies
+    hsts: Union[Literal[False], HSTSOption]  # Strict-Transport-Security
+    wshsts: Union[Literal[False], WsHSTSOption]  # WebSocket-Strict-Transport-Security
+    xframe: Union[Literal[False], TXFrameOption, XFrameOption]  # X-Frame-Options
+    clearSiteData: Union[Literal[False], ClearSiteDataOption]  # Clear-Site-Data
+    cacheControl: Union[Literal[False], CacheControlOption]  # Cache-Control
+    PermissionPolicy: Union[Literal[False], PermissionsPolicyOption]  # Permissions-Policy
 
 class SecWeb:
     """This Class is used for initializing all the middlewares CSP, COOP, etc
@@ -43,53 +66,16 @@ class SecWeb:
 
      report_only=False This is an optional flag it will set the Content-Security-Policy-Report-Only header instead of the Content-Security-Policy header
 
-    Values :
-        'csp' for ContentSecurityPolicy
-
-        'coop' for CrossOriginOpenerPolicy
-
-        'coep' for CrossOriginEmbedderPolicy
-
-        'corp' for CrossOriginResourcePolicy
-
-        'referrer' for ReferrerPolicy
-
-        'xdns' for XDNSPrefetchControl
-
-        'xcdp' for XPermittedCrossDomainPolicies
-
-        'hsts' for HSTS/StrictTransportSecurity
-
-        'wshsts' for HSTS/StrictTransportSecurity for websockets
-
-        'xframe' for XFrame
-
-        'PermissionPolicy' for PermissionPoilcy
-
-        'clearSiteData' for Clear-Site-Data
-
-        'cacheControl' for Cache-Control
-
-        'xcto' for X-Content-Type-Options
-
-        'xdo' for X-Download-Options
-
-        'xss' for x-xss-protection
-
-        'oac' for Origin-Agent-Cluster
-
-    This Values are for the Option parameter
-    
     """
 
     def __init__(
         self,
-        app,
-        Option = {},
-        Routes = [],
-        script_nonce = False,
-        style_nonce = False,
-        report_only = False
+        app: Starlette,
+        Option: SecWebOption = {},
+        Routes: list[str] = [],
+        script_nonce: bool = False,
+        style_nonce: bool = False,
+        report_only: bool = False
     ) -> None:
         """
         Initializes an instance of the class.
@@ -121,7 +107,7 @@ class SecWeb:
             app.add_middleware(CrossOriginEmbedderPolicy)
             app.add_middleware(CrossOriginOpenerPolicy)
             app.add_middleware(CrossOriginResourcePolicy)
-            if Routes.__len__() > 0:
+            if len(Routes) > 0:
                 app.add_middleware(ClearSiteData, Routes=Routes)
         else:
             if "xdo" in Option.keys() and Option["xdo"] is False:

--- a/src/Secweb/xXSSProtection/__init__.py
+++ b/src/Secweb/xXSSProtection/__init__.py
@@ -1,1 +1,5 @@
 from .xXSSProtectionMiddleware import xXSSProtection
+
+__all__ = [
+    "xXSSProtection",
+]

--- a/src/Secweb/xXSSProtection/xXSSProtectionMiddleware.py
+++ b/src/Secweb/xXSSProtection/xXSSProtectionMiddleware.py
@@ -3,8 +3,10 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   Copyright 2021-2025, Motagamwala Taha Arif Ali '''
-
+from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
+from starlette.types import Scope, Receive, Send, Message
+
 
 class xXSSProtection:
     ''' xXSSProtection class sets X-XSS-Protection header.
@@ -13,7 +15,7 @@ class xXSSProtection:
         app.add_middleware(xXSSProtection)
     
     '''
-    def __init__(self, app):
+    def __init__(self, app: Starlette):
         """
         Initializes a new instance of the class.
 
@@ -25,7 +27,7 @@ class xXSSProtection:
         """
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Asynchronously handles HTTP requests by routing them to the appropriate handler based on the request path.
 
@@ -40,7 +42,7 @@ class xXSSProtection:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        async def set_x_XSS_Protection(message):
+        async def set_x_XSS_Protection(message: Message) -> None:
             """
             Sets the X-XSS-Protection header to '0' in the HTTP response header.
         


### PR DESCRIPTION

This pull request includes several updates to the Secweb project, focusing on adding type annotations, enhancing middleware options, and improving the CI workflow. The most important changes include the addition of type annotations for middleware classes, the inclusion of new middleware options, and the setup of a GitHub Actions workflow for running tests.

### Type Annotations and Middleware Enhancements:
Added type annotations and defined middlewares `Option` using `TypedDict` to specify options. 
### CI Workflow:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR1-R28): Added a GitHub Actions workflow to run tests on multiple Python versions (3.9 to 3.14).

### Dependency Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R6-R32): Updated the `requires-python` version to `>=3.9` as `3.8` is not supported anymore https://devguide.python.org/versions/  and added `starlette` as a dependency. Also, added mypy configuration for stricter type checking.
